### PR TITLE
RFC: decode: Recover from overflow using timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,18 @@ CACHE_MODE := 1
 
 PRINT_EDGE_COV := 0
 
+OVERFLOW_TH := 0x10000
+
 ifeq ($(CACHE_MODE), 1)
 	CXXFLAGS += -DCACHE_MODE
 endif
 
 ifeq ($(PRINT_EDGE_COV), 1)
 	CXXFLAGS += -DPRINT_EDGE_COV
+endif
+
+ifneq ($(strip $(OVERFLOW_TH)),)
+	CXXFLAGS += -DOVERFLOW_TH=$(OVERFLOW_TH)
 endif
 
 SRCS := $(SRC_DIR)/decoder.cpp \

--- a/include/decoder.hpp
+++ b/include/decoder.hpp
@@ -46,6 +46,9 @@ struct Packet
 
     // Address packet
     uint64_t addr;
+
+    // Timestamp packet
+    uint64_t timestamp = 0;
 };
 
 
@@ -66,9 +69,12 @@ struct BranchPacket
 
     // for ADDRESS packet (indirect branch)
     uint64_t target_address;
+
+    // for TIMESTAMP packet (last timestamp)
+    uint64_t timestamp = 0;
 };
 
 
 std::optional<BranchPacket> decodeNextBranchPacket(const std::vector<uint8_t>& trace_data,
-    std::size_t &trace_data_offset);
+    std::size_t &trace_data_offset, uint64_t last_timestamp);
 void printPacket(const Packet packet);

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -365,11 +365,13 @@ Packet decodeTimestampPacket(const std::vector<uint8_t> &trace_data, const size_
     }
 
     uint64_t timestamp = 0;
-    for (int i = 1; i <= 7; i++) {
-        uint64_t val = trace_data[offset + i];
-        val = i < 7 ? val & ~0x80 : val;
-        timestamp |= val << (7 * (i - 1));
-    }
+    timestamp |= ((uint64_t)trace_data[offset + 1] & ~0x80) << (7 * 0);
+    timestamp |= ((uint64_t)trace_data[offset + 2] & ~0x80) << (7 * 1);
+    timestamp |= ((uint64_t)trace_data[offset + 3] & ~0x80) << (7 * 2);
+    timestamp |= ((uint64_t)trace_data[offset + 4] & ~0x80) << (7 * 3);
+    timestamp |= ((uint64_t)trace_data[offset + 5] & ~0x80) << (7 * 4);
+    timestamp |= ((uint64_t)trace_data[offset + 6] & ~0x80) << (7 * 5);
+    timestamp |= ((uint64_t)trace_data[offset + 7]) << (7 * 6);
 
     Packet packet = {
         ETM4_PKT_I_TIMESTAMP,

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -7,8 +7,6 @@
 #include "utils.hpp"
 #include "deformatter.hpp"
 
-const uint64_t overflow_threshold = 0x10000;
-
 Packet decodePacket(const std::vector<uint8_t> &trace_data, const size_t offset);
 
 Packet decodeExtensionPacket(const std::vector<uint8_t> &trace_data, const size_t offset);
@@ -142,7 +140,7 @@ std::optional<BranchPacket> decodeNextBranchPacket(const std::vector<uint8_t>& t
                     // A timestamp packet found in OVERFLOW state.
                     // If the delta of two timestamp values are acceptable,
                     // recover decoding previous state and continue.
-                    if (packet.timestamp - timestamp < overflow_threshold) {
+                    if (packet.timestamp - timestamp < OVERFLOW_TH) {
                         state = prev_state;
                     } else {
                         std::cerr << "Found an overflow packet and not recoverable. ";


### PR DESCRIPTION
libxml2など比較的大きな対象をAFL++ CoreSight modeで実行したときに頻繁にoverflow packetが出力されるため，overflow packetがあった場合にすぐにデコードを失敗させる現在の実装では現実的に実行が困難であった．
overflow packetはETFなどのtrace sinkにパケットが保存される前の上流にあるETMが持っているバッファのオーバーフロー時に生成される．ETFのオーバーフローと異なり，こちらで監視と制御ができないという問題がある．

このPRではoverflow packetの前後のtimestampの値を見て閾値以下であればoverflowにより欠損したパケットはないと判断し，デコードを続けるように変更を加えている．

これによりlibxml2のAFL++ CoreSight modeでのファジングができることを確認している．

Signed-off-by: Akira Moroo <retrage01@gmail.com>